### PR TITLE
Remove double slash in filename

### DIFF
--- a/src/Fillet/Writer/PostWriter.php
+++ b/src/Fillet/Writer/PostWriter.php
@@ -34,7 +34,7 @@ class PostWriter extends AbstractWriter
 		$dumper = new YamlDumper();
 		$header = '---' . PHP_EOL . $dumper->dump($headerData, 2) . '---' . PHP_EOL;
 
-        $filename = $this->destinationFolder . '/' . $filename;
+        $filename = $this->destinationFolder . $filename;
         if ($this->isMarkdownEnabled()) {
             $filename .= '.md';
             $data['content'] = $this->toMarkdown($data['content']);


### PR DESCRIPTION
I noticed whilst working on the DrupalParser that there's a double-slash in the destination filename.

It doesn't stop the content from being written to the file, but I thought it would be worth quickly fixing it.
